### PR TITLE
Add project README and align env example variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,15 +1,26 @@
 # --- Databases ---
-POSTGRES_DATABASE_URL=postgresql+asyncpg://USER:PASS@HOST:PORT/postgres
-PARSING_DATABASE_URL=postgresql+asyncpg://USER:PASS@HOST:PORT/parsing_data
+# Указывайте DSN в формате postgresql+psycopg://USER:PASS@HOST:PORT/db_name
+POSTGRES_URL=postgresql+psycopg://USER:PASS@HOST:PORT/postgres
+PARSING_URL=postgresql+psycopg://USER:PASS@HOST:PORT/parsing_data
+ECHO_SQL=false
 
-# --- OpenAI ---
+# --- OpenAI / Embeddings ---
 OPENAI_API_KEY=sk-***your_key***
 CHAT_MODEL=gpt-4o
-EMBED_MODEL=text-embedding-3-large
+OPENAI_EMBED_MODEL=text-embedding-3-large
+VECTOR_DIM=3072
 
-# --- Default write mode ---
+# --- Внутренний сервис эмбеддингов (опционально) ---
+INTERNAL_EMBED_URL=
+INTERNAL_EMBED_TIMEOUT=6.0
+
+# --- AI Search ---
+AI_SEARCH_TIMEOUT=12.0
+AI_SEARCH_RATE_LIMIT_PER_MIN=10
+
+# --- Режим записи ---
 # primary_only | dual_write | fallback_to_secondary
-DEFAULT_SYNC_MODE=primary_only
+DEFAULT_WRITE_MODE=primary_only
 
 # --- CORS (optional) ---
 CORS_ALLOW_ORIGINS=http://localhost:3000
@@ -19,3 +30,9 @@ CORS_ALLOW_CREDENTIALS=false
 
 # --- Logging ---
 LOG_LEVEL=INFO
+
+# --- Отладочные флаги эмбеддингов (опционально) ---
+EMBED_PREVIEW_CHARS=160
+EMBED_BATCH_SIZE=96
+EMBED_MAX_CHARS=200000
+DEBUG_OPENAI_LOG=false

--- a/README.md
+++ b/README.md
@@ -1,0 +1,97 @@
+# AI Site Analyzer
+
+AI Site Analyzer — это асинхронный сервис на FastAPI, который анализирует сайты и
+возвращает структурированный отчёт. Сервис работает поверх двух PostgreSQL
+баз, обращается к OpenAI для генерации отчётов и эмбеддингов, а также
+предоставляет вспомогательный эндпоинт `/api/ai-search` для получения
+векторных представлений текстов.
+
+## Основные возможности
+
+- **Анализ сайтов по `pars_id` или домену.** Основные эндпоинты располагаются в
+  `app/api/routes.py` и принимают запросы `POST /v1/analyze/{pars_id}` и
+  `POST /v1/analyze/by-site/{site}`.
+- **Поддержка двух баз данных.** Используются асинхронные движки SQLAlchemy с
+  ленивой инициализацией и отдельными DSN для `postgres` и `parsing_data`.
+- **Интеграция с OpenAI.** Модуль `app/services/analyzer.py` собирает промпт,
+  вызывает LLM и разбирает ответ, а `app/services/embeddings.py` отвечает за
+  получение эмбеддингов (внутренний сервис → OpenAI fallback).
+- **Сервис эмбеддингов `/api/ai-search`.** Реализован в
+  `app/routers/ai_search.py`, включает простой rate limit, нормализацию запросов
+  и возможность подключить внутренний провайдер эмбеддингов.
+- **Единая конфигурация через `.env`.** Настройки описаны в `app/config.py` и
+  автоматически нормализуются (алиасы, значения по умолчанию, computed-поля).
+
+## Структура проекта
+
+```text
+app/
+├── api/                # публичные REST-роуты и pydantic-схемы
+├── db/                 # создание движков, транзакции и пинг баз данных
+├── models/             # справочники/модели домена
+├── repositories/       # работа с БД (чтение текстов, поиск pars_id)
+├── routers/            # дополнительные роутеры (ai-search)
+├── schemas/            # pydantic-схемы для ai-search
+├── services/           # интеграция с OpenAI, логика анализа
+├── utils/              # вспомогательные утилиты (rate limiter и др.)
+├── config.py           # pydantic Settings для загрузки окружения
+├── logging_setup.py    # базовая настройка логирования
+└── main.py             # точка входа FastAPI-приложения
+```
+
+## Подготовка окружения
+
+1. **Python.** Требуется Python 3.11+.
+2. **Зависимости.** Установите пакеты: `pip install -r requirements.txt`.
+3. **Переменные окружения.** Скопируйте пример и укажите свои значения:
+   ```bash
+   cp .env.example .env
+   ```
+   Минимальный набор — DSN для PostgreSQL и ключ OpenAI. Полный список
+   переменных приведён ниже.
+4. **Запуск.** Используйте любой из вариантов:
+   ```bash
+   uvicorn app.main:app --host 0.0.0.0 --port 8090 --reload
+   # или
+   python -m app.run
+   ```
+
+После запуска основное приложение доступно на `http://localhost:8090`.
+
+## Ключевые переменные `.env`
+
+| Переменная | Назначение |
+| --- | --- |
+| `POSTGRES_URL` | DSN основной БД (`postgresql+psycopg://…`). |
+| `PARSING_URL` | DSN БД `parsing_data`. |
+| `ECHO_SQL` | Логирование SQL (true/false). |
+| `OPENAI_API_KEY` | Ключ OpenAI для генерации отчётов и эмбеддингов. |
+| `CHAT_MODEL` | Модель диалога для анализа (по умолчанию `gpt-4o`). |
+| `OPENAI_EMBED_MODEL` | Модель эмбеддингов (по умолчанию `text-embedding-3-large`). |
+| `INTERNAL_EMBED_URL` | URL внутреннего сервиса эмбеддингов (опционально). |
+| `AI_SEARCH_TIMEOUT` | Таймаут `POST /api/ai-search` в секундах. |
+| `AI_SEARCH_RATE_LIMIT_PER_MIN` | Лимит запросов `/api/ai-search` в минуту. |
+| `DEFAULT_WRITE_MODE` | Режим записи (`primary_only`, `dual_write`, `fallback_to_secondary`). |
+| `CORS_ALLOW_*` | Настройки CORS (origins, methods, headers, credentials). |
+| `LOG_LEVEL` | Уровень логирования FastAPI-приложения. |
+
+Дополнительные параметры (например, `VECTOR_DIM`, `EMBED_BATCH_SIZE`,
+`EMBED_MAX_CHARS`, `DEBUG_OPENAI_LOG`) можно оставить по умолчанию или
+переопределить при необходимости.
+
+## Проверка работоспособности
+
+- `GET /health` — проверка подключения к базам.
+- `POST /v1/analyze/{pars_id}` — анализ по идентификатору.
+- `POST /v1/analyze/by-site/{site}` — анализ по домену.
+- `GET /api/ai-search/health` — health чек сервиса эмбеддингов.
+- `POST /api/ai-search` — получение эмбеддинга или fallback-ответов.
+
+## Полезные советы
+
+- Логирование уже настроено в `app/logging_setup.py`. При необходимости
+  используйте переменную `LOG_LEVEL` или переопределите формат.
+- В продакшене стоит подключить внешнее управление миграциями (Alembic) и
+  секретами (Vault, AWS Secrets Manager и т.д.).
+- Для локальной разработки можно настроить docker-compose с PostgreSQL и
+  пробросить DSN через `.env`.


### PR DESCRIPTION
## Summary
- add a detailed README that documents the service architecture, setup, and key endpoints
- refresh `.env.example` to use the current variable names and include additional optional settings

## Testing
- not run (not requested)