### PR TITLE
Add API endpoint for IB catalog matching

### DIFF
--- a/app/api/schemas.py
+++ b/app/api/schemas.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import Any, Dict, Literal
+from typing import Any, Dict, List, Literal
 from pydantic import BaseModel, Field
 
 
@@ -20,4 +20,38 @@ class AnalyzeResponse(BaseModel):
     answer_raw: str | None
     parsed: Dict[str, Any]
     report: Dict[str, Any] | None
+    duration_ms: int
+
+
+class IbMatchRequest(BaseModel):
+    client_id: int = Field(..., ge=1)
+    reembed_if_exists: bool = False
+    sync_mode: Literal["primary_only", "dual_write", "fallback_to_secondary"] | None = None
+
+
+class IbMatchItem(BaseModel):
+    ai_id: int
+    source_text: str
+    match_id: int | None
+    match_name: str | None
+    score: float | None
+    note: str | None = None
+
+
+class IbMatchSummary(BaseModel):
+    goods_total: int
+    goods_updated: int
+    goods_embedded: int
+    equipment_total: int
+    equipment_updated: int
+    equipment_embedded: int
+    catalog_goods_total: int
+    catalog_equipment_total: int
+
+
+class IbMatchResponse(BaseModel):
+    client_id: int
+    goods: List[IbMatchItem]
+    equipment: List[IbMatchItem]
+    summary: IbMatchSummary
     duration_ms: int

--- a/app/utils/vectors.py
+++ b/app/utils/vectors.py
@@ -1,0 +1,59 @@
+"""Utility helpers for working with pgvector columns and cosine similarity."""
+from __future__ import annotations
+
+from math import sqrt
+from typing import List, Optional, Sequence
+
+
+def parse_pgvector(value: Optional[str]) -> Optional[List[float]]:
+    """Parse a textual pgvector representation ("[1,2,3]") into a list of floats."""
+    if value is None:
+        return None
+    text = value.strip()
+    if not text:
+        return None
+    if text.startswith("[") and text.endswith("]"):
+        text = text[1:-1]
+    if not text:
+        return []
+    parts = [p.strip() for p in text.split(",") if p.strip()]
+    if not parts:
+        return []
+    try:
+        return [float(item) for item in parts]
+    except ValueError:
+        return None
+
+
+def format_pgvector(values: Sequence[float]) -> str:
+    """Format a sequence of floats into pgvector textual representation."""
+    return "[" + ",".join(f"{float(v):.7f}" for v in values) + "]"
+
+
+def cosine_similarity(a: Sequence[float], b: Sequence[float]) -> float:
+    """Return cosine similarity in the range [0, 1]."""
+    if not a or not b:
+        return 0.0
+    length = min(len(a), len(b))
+    if length == 0:
+        return 0.0
+    dot = 0.0
+    norm_a = 0.0
+    norm_b = 0.0
+    for i in range(length):
+        av = float(a[i])
+        bv = float(b[i])
+        dot += av * bv
+        norm_a += av * av
+        norm_b += bv * bv
+    if norm_a <= 0.0 or norm_b <= 0.0:
+        return 0.0
+    denom = sqrt(norm_a) * sqrt(norm_b)
+    if denom <= 0.0:
+        return 0.0
+    sim = dot / denom
+    if sim < 0.0:
+        return 0.0
+    if sim > 1.0:
+        return 1.0
+    return sim


### PR DESCRIPTION
## Summary
- add a /v1/ib-match endpoint that embeds site data, matches it against IB catalogs, updates scores, and returns a detailed report
- define request/response schemas plus vector helpers for parsing pgvector values and cosine similarity calculations
- extend the parsing repository with queries and update helpers for company goods and equipment entries