### PR TITLE
Add detailed debug report to IB match API response

### DIFF
--- a/app/api/schemas.py
+++ b/app/api/schemas.py
@@ -54,4 +54,5 @@ class IbMatchResponse(BaseModel):
     goods: List[IbMatchItem]
     equipment: List[IbMatchItem]
     summary: IbMatchSummary
+    debug_report: str | None = None
     duration_ms: int


### PR DESCRIPTION
## Summary
- add an ASCII table helper and build a verbose debug report string for /v1/ib-match
- extend the IbMatchResponse schema to expose the debug report alongside the existing payload

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68de35fa81008328b03ec775c1aff164